### PR TITLE
bugfix: values comparison on CalledWith methods

### DIFF
--- a/mock/method.go
+++ b/mock/method.go
@@ -1,5 +1,7 @@
 package mock
 
+import "reflect"
+
 // method represents a mock use information, but filtered for a specific method
 type method struct {
 	name string
@@ -85,7 +87,7 @@ func (m *method) CalledWithExactly(args ...any) bool {
 
 		hasExactArgs := true
 		for i, callArg := range call.Args {
-			if args[i] != callArg {
+			if !reflect.DeepEqual(args[i], callArg) {
 				hasExactArgs = false
 				break
 			}

--- a/mock/method_test.go
+++ b/mock/method_test.go
@@ -198,6 +198,43 @@ func TestMethodCalledWith(t *testing.T) {
 		mock.RegisterMethodCall("MyFunc1", arg1, arg2, "anotherArg")
 		assert.True(t, method1.CalledWith(arg2, arg1))
 	})
+	t.Run("Should be able to compare slices", func(t *testing.T) {
+		mock := NewMock()
+		method := mock.Method("MyFunc1")
+
+		sliceArg := []string{"1", "2", "3"}
+
+		mock.RegisterMethodCall("MyFunc1", sliceArg)
+
+		res := method.CalledWith(sliceArg)
+		assert.True(t, res)
+
+		res = method.CalledWith([]string{"3", "2", "1"})
+		assert.False(t, res)
+
+		res = method.CalledWith(20)
+		assert.False(t, res)
+	})
+	t.Run("Should be able to compare maps", func(t *testing.T) {
+		mock := NewMock()
+		method := mock.Method("MyFunc1")
+
+		mapArg := map[string]int{"1": 3, "2": 4, "3": 5}
+
+		mock.RegisterMethodCall("MyFunc1", mapArg)
+
+		res := method.CalledWith(mapArg)
+		assert.True(t, res)
+
+		res = method.CalledWith(map[string]int{"3": 5, "2": 4, "1": 3})
+		assert.True(t, res)
+
+		res = method.CalledWith(map[string]int{"3": 5, "2": 4})
+		assert.False(t, res)
+
+		res = method.CalledWith(20)
+		assert.False(t, res)
+	})
 }
 
 func TestMethodCalledWithExactly(t *testing.T) {
@@ -247,5 +284,42 @@ func TestMethodCalledWithExactly(t *testing.T) {
 
 		assert.True(t, method1.CalledWithExactly(arg1, arg2))
 		assert.True(t, method2.CalledWithExactly(arg2, "someOtherArg"))
+	})
+	t.Run("Should be able to compare slices", func(t *testing.T) {
+		mock := NewMock()
+		method := mock.Method("MyFunc1")
+
+		sliceArg := []string{"1", "2", "3"}
+
+		mock.RegisterMethodCall("MyFunc1", sliceArg)
+
+		res := method.CalledWithExactly(sliceArg)
+		assert.True(t, res)
+
+		res = method.CalledWithExactly([]string{"3", "2", "1"})
+		assert.False(t, res)
+
+		res = method.CalledWithExactly(20)
+		assert.False(t, res)
+	})
+	t.Run("Should be able to compare maps", func(t *testing.T) {
+		mock := NewMock()
+		method := mock.Method("MyFunc1")
+
+		mapArg := map[string]int{"1": 3, "2": 4, "3": 5}
+
+		mock.RegisterMethodCall("MyFunc1", mapArg)
+
+		res := method.CalledWithExactly(mapArg)
+		assert.True(t, res)
+
+		res = method.CalledWithExactly(map[string]int{"3": 5, "2": 4, "1": 3})
+		assert.True(t, res)
+
+		res = method.CalledWithExactly(map[string]int{"3": 5, "2": 4})
+		assert.False(t, res)
+
+		res = method.CalledWithExactly(20)
+		assert.False(t, res)
 	})
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,5 +1,7 @@
 package mock
 
+import "reflect"
+
 // Mock represents a mock and its use information
 type Mock struct {
 	responses map[string]methodResponse
@@ -86,7 +88,7 @@ func (mock *Mock) CalledWithExactly(args ...any) bool {
 
 		hasExactArgs := true
 		for i, callArg := range call.Args {
-			if args[i] != callArg {
+			if !reflect.DeepEqual(args[i], callArg) {
 				hasExactArgs = false
 				break
 			}

--- a/mock/mock_call.go
+++ b/mock/mock_call.go
@@ -1,5 +1,7 @@
 package mock
 
+import "reflect"
+
 // MockCall represents a mock call, with the call arguments
 type MockCall struct {
 	MethodName string
@@ -9,7 +11,7 @@ type MockCall struct {
 // HasArgument checks if a mock call arguments contains a specific argument
 func (mc *MockCall) HasArgument(arg any) bool {
 	for _, a := range mc.Args {
-		if a == arg {
+		if reflect.DeepEqual(a, arg) {
 			return true
 		}
 	}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -257,6 +257,43 @@ func TestCalledWith(t *testing.T) {
 		res = m.CalledWith(arg1, arg2)
 		assert.True(t, res)
 	})
+	t.Run("Should be able to compare slices", func(t *testing.T) {
+		m := NewMock()
+		sliceArg := []string{"1", "2", "3"}
+
+		m.calls = []MockCall{
+			{Args: []any{sliceArg}},
+		}
+
+		res := m.CalledWith(sliceArg)
+		assert.True(t, res)
+
+		res = m.CalledWith([]string{"3", "2", "1"})
+		assert.False(t, res)
+
+		res = m.CalledWith(20)
+		assert.False(t, res)
+	})
+	t.Run("Should be able to compare maps", func(t *testing.T) {
+		m := NewMock()
+		mapArg := map[string]int{"1": 3, "2": 4, "3": 5}
+
+		m.calls = []MockCall{
+			{Args: []any{mapArg}},
+		}
+
+		res := m.CalledWith(mapArg)
+		assert.True(t, res)
+
+		res = m.CalledWith(map[string]int{"3": 5, "2": 4, "1": 3})
+		assert.True(t, res)
+
+		res = m.CalledWith(map[string]int{"3": 5, "2": 4})
+		assert.False(t, res)
+
+		res = m.CalledWith(20)
+		assert.False(t, res)
+	})
 }
 
 func TestCalledWithExactly(t *testing.T) {
@@ -320,6 +357,43 @@ func TestCalledWithExactly(t *testing.T) {
 		}
 		res = m.CalledWithExactly(arg1, arg2)
 		assert.True(t, res)
+	})
+	t.Run("Should be able to compare slices", func(t *testing.T) {
+		m := NewMock()
+		sliceArg := []string{"1", "2", "3"}
+
+		m.calls = []MockCall{
+			{Args: []any{sliceArg}},
+		}
+
+		res := m.CalledWithExactly(sliceArg)
+		assert.True(t, res)
+
+		res = m.CalledWithExactly([]string{"3", "2", "1"})
+		assert.False(t, res)
+
+		res = m.CalledWithExactly(20)
+		assert.False(t, res)
+	})
+	t.Run("Should be able to compare maps", func(t *testing.T) {
+		m := NewMock()
+		mapArg := map[string]int{"1": 3, "2": 4, "3": 5}
+
+		m.calls = []MockCall{
+			{Args: []any{mapArg}},
+		}
+
+		res := m.CalledWithExactly(mapArg)
+		assert.True(t, res)
+
+		res = m.CalledWithExactly(map[string]int{"3": 5, "2": 4, "1": 3})
+		assert.True(t, res)
+
+		res = m.CalledWithExactly(map[string]int{"3": 5, "2": 4})
+		assert.False(t, res)
+
+		res = m.CalledWithExactly(20)
+		assert.False(t, res)
 	})
 }
 


### PR DESCRIPTION
### Descrição
Passa a usar a lib `reflect` do Go para comparar valores, ao invés de usar o operador `==`

Isso foi feito por que o operador `==` não é capaz de comparar corretamente valores complexos como slices, maps e structs.

### Checklist
- [x] Foi executado localmente
- [x] Foi testado no ambiente de dev
- [x] Foi escrito os testes necessários
- [x] Estou atribuído como owner do PR
- [x] Review solicitado para time correto
- [x] O `.env-example` está atualizado
